### PR TITLE
Adds check to raycast to ensure mouse is not over button

### DIFF
--- a/Assets/Scripts/Battlefield/TurnBrain.cs
+++ b/Assets/Scripts/Battlefield/TurnBrain.cs
@@ -5,6 +5,7 @@ using SwordAndBored.Battlefield.CreaturScripts;
 using SwordAndBored.Battlefield.TurnMechanism;
 using SwordAndBored.Battlefield.CameraUtilities;
 using Cinemachine;
+using UnityEngine.EventSystems;
 
 namespace SwordAndBored.Battlefield
 {
@@ -108,8 +109,10 @@ namespace SwordAndBored.Battlefield
             {
                 Tile currentTile = hit.collider.GetComponent<Tile>();
                 tileIndictor.transform.position = currentTile.GetPos();
+
                 if (currentTile.unitOnTile == null && Input.GetButtonDown("Fire1"))
                 {
+                    if (EventSystem.current.IsPointerOverGameObject()) return;
                     creature.Move(currentTile);
                 }
             }


### PR DESCRIPTION
Fixes #83  .

Changes proposed in this pull request:
- Adds a check to the raycast which controls highlighting and clicking on tiles which makes sure the mouse is not over a button before attempting to detect tiles.

