### PR TITLE
82 Units now delete their extranious objects on death

### DIFF
--- a/Assets/Prefabs/UnitBase.prefab
+++ b/Assets/Prefabs/UnitBase.prefab
@@ -1703,6 +1703,7 @@ MonoBehaviour:
   stats: {fileID: 0}
   currentCamera: {fileID: 3159141201642896361}
   animator: {fileID: 3159141201733096179}
+  target: {fileID: 3159141201168309834}
 --- !u!114 &3159141201095183990
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1731,11 +1732,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   health: 0
   attack: 0
-  specialAttack: 0
+  magicAttack: 0
   defense: 0
-  specialDefense: 0
+  magicDefense: 0
   speedIntit: 0
   movement: 0
+  accuracy: 0
+  evasion: 0
+  role: 
 --- !u!114 &3159141201095183992
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battlefield/Camera/CameraTarget.cs
+++ b/Assets/Scripts/Battlefield/Camera/CameraTarget.cs
@@ -24,6 +24,12 @@ namespace SwordAndBored.Battlefield.CameraUtilities
                 transform.position = player.position;
             }
             
+
+
+            if (!player)
+            {
+                Destroy(transform.gameObject);
+            }
         }
     }
 

--- a/Assets/Scripts/Battlefield/CreatureScripts/CreatureBase.cs
+++ b/Assets/Scripts/Battlefield/CreatureScripts/CreatureBase.cs
@@ -30,14 +30,6 @@ namespace SwordAndBored.Battlefield.CreaturScripts
             movement = maxMovement;
         }
 
-        void Update()
-        {
-            if (health <= 0)
-            {
-                Destroy(transform.gameObject);
-            }    
-        }
-
         public void Damage(int damage)
         {
             health -= damage;

--- a/Assets/Scripts/Battlefield/CreatureScripts/UniqueCreature.cs
+++ b/Assets/Scripts/Battlefield/CreatureScripts/UniqueCreature.cs
@@ -20,6 +20,7 @@ namespace SwordAndBored.Battlefield.CreaturScripts {
         [Header("Virtual Camera Info")]
         public CinemachineVirtualCamera currentCamera;
         public Animator animator;
+        public Transform target;
         
 
         void Start()
@@ -55,6 +56,14 @@ namespace SwordAndBored.Battlefield.CreaturScripts {
 
         private void Update()
         {
+            if (health <= 0)
+            {
+                Destroy(target.gameObject);
+                Destroy(currentCamera.gameObject);
+                Destroy(transform.gameObject);
+            }
+
+
             if (highlightColor == 3 && Time.time > b)
             {
                 Glow(2);


### PR DESCRIPTION
Fixes #82  .

Changes proposed in this pull request:
- Camera targets deleted themselves when their player is gone

