### PR TITLE
Add IsSetInEditor assert function

### DIFF
--- a/Assets/Scripts/Utilities/Debug.meta
+++ b/Assets/Scripts/Utilities/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df9d915e2fb9d6b42adfe407bc33ca28
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/Debug/AssertHelper.cs
+++ b/Assets/Scripts/Utilities/Debug/AssertHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace SwordAndBored.Utilities.Debug
+{
+    static class AssertHelper
+    {
+        /// <summary>
+        /// Checks to make sure an object has been set in the editor on debug builds
+        /// </summary>
+        /// <typeparam name="T">The type of object that is being checked</typeparam>
+        /// <param name="obj">The object that is being checked</param>
+        /// <param name="context">The unity object where the object being checked should have been set</param>
+        [Conditional("DEBUG")]
+        public static void IsSetInEditor<T>(T obj, UnityEngine.Object context) where T : class
+        {
+            if (obj is null)
+            {
+                UnityEngine.Debug.LogError(typeof(T).Name + " is not set for " + context.GetType().Name, context);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Utilities/Debug/AssertHelper.cs.meta
+++ b/Assets/Scripts/Utilities/Debug/AssertHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef0ab5ac8e825b24a8564f5cd2f873de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### What is it?
A function that can check whether an object has been set in the editor. The function is only run on DEBUG builds. The functions logs an error if the object is null and clearly specifies where the missing object should be.

### How to use it
Make sure to include `using SwordAndBored.Utilities.Debug`, then
If your `MonoBehaviour` has an awake function (this could also be checked in a start or later function)
```cs
void Awake()
{
    // Your code
    AssertHelper.IsSetInEditor(variableToCheck, this)
    // Rest of code
}
```
If your MonoBehaviour doesn't have a start or awake function but you want to check it at that time
```cs
#if DEBUG
void Awake()
{
     AssertHelper.IsSetInEditor(variableToCheck, this)
}
#endif
```

