### PR TITLE
108 turn time

### DIFF
--- a/Assets/Prefabs/TimeManagerContainer.prefab
+++ b/Assets/Prefabs/TimeManagerContainer.prefab
@@ -1,0 +1,490 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4568864099801203047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4568864099801203046}
+  - component: {fileID: 4568864099801202840}
+  - component: {fileID: 4568864099801202841}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4568864099801203046
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864099801203047}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4568864100176398330}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4568864099801202840
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864099801203047}
+  m_CullTransparentMesh: 0
+--- !u!114 &4568864099801202841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864099801203047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: End Turn
+--- !u!1 &4568864099817044026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4568864099817044028}
+  - component: {fileID: 4568864099817044029}
+  - component: {fileID: 4568864099817044031}
+  m_Layer: 0
+  m_Name: Time Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4568864099817044028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864099817044026}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8411405351447285188}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4568864099817044029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864099817044026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5411f1825cf34c041a1dd04719537b27, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startingTimeStep: 0
+--- !u!114 &4568864099817044031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864099817044026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7750ba802c98e64429dd3c5d6459d204, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeManager: {fileID: 4568864099817044029}
+  nextTurnKey: 13
+--- !u!1 &4568864100107378782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4568864100107378770}
+  - component: {fileID: 4568864100107378771}
+  - component: {fileID: 4568864100107378768}
+  - component: {fileID: 4568864100107378769}
+  m_Layer: 5
+  m_Name: TurnDisplayCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4568864100107378770
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100107378782}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 4568864100176398330}
+  - {fileID: 4568864100271234954}
+  m_Father: {fileID: 8411405351447285188}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &4568864100107378771
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100107378782}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4568864100107378768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100107378782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &4568864100107378769
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100107378782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &4568864100176398331
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4568864100176398330}
+  - component: {fileID: 4568864100176398335}
+  - component: {fileID: 4568864100176398332}
+  - component: {fileID: 4568864100176398333}
+  m_Layer: 5
+  m_Name: EndTurnButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4568864100176398330
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100176398331}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4568864099801203046}
+  m_Father: {fileID: 4568864100107378770}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 60, y: -30}
+  m_SizeDelta: {x: 80, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4568864100176398335
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100176398331}
+  m_CullTransparentMesh: 0
+--- !u!114 &4568864100176398332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100176398331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4568864100176398333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100176398331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4568864100176398332}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4568864099817044029}
+        m_MethodName: AdvanceTimeStep
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &4568864100271234955
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4568864100271234954}
+  - component: {fileID: 4568864100271234959}
+  - component: {fileID: 4568864100271234956}
+  - component: {fileID: 4568864100271234957}
+  m_Layer: 5
+  m_Name: CurrentTurnText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4568864100271234954
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100271234955}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4568864100107378770}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -20, y: -35}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4568864100271234959
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100271234955}
+  m_CullTransparentMesh: 0
+--- !u!114 &4568864100271234956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100271234955}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Turn: 00000'
+--- !u!114 &4568864100271234957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4568864100271234955}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 062b18826d8b41e43b3bcadb20b6a0eb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeManager: {fileID: 4568864099817044029}
+--- !u!1 &4767492386198566431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8411405351447285188}
+  m_Layer: 0
+  m_Name: TimeManagerContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8411405351447285188
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4767492386198566431}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4568864099817044028}
+  - {fileID: 4568864100107378770}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/TimeManagerContainer.prefab.meta
+++ b/Assets/Prefabs/TimeManagerContainer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6107062eab8ff43429b23bd9cfed7e6c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem.meta
+++ b/Assets/Scripts/Strategy/TimeSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6451254900f77c45b1ada0c48f758f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80fa22bfc6833cd4789eceb3cc5aee9a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs
@@ -1,0 +1,7 @@
+﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
+{
+    interface IPostTimeStepSubscriber
+    {
+        void PostTimeStepUpdate();
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs
@@ -1,7 +1,13 @@
 ﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
 {
+    /// <summary>
+    /// A subscriber that is notified after a time step ends but before the next one starts
+    /// </summary>
     public interface IPostTimeStepSubscriber
     {
+        /// <summary>
+        /// The function the time manager calls after the time step ends but before the next one starts
+        /// </summary>
         void PostTimeStepUpdate();
     }
 }

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
 {
-    interface IPostTimeStepSubscriber
+    public interface IPostTimeStepSubscriber
     {
         void PostTimeStepUpdate();
     }

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPostTimeStepSubscriber.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80c40731be25efd479bc585daa83a9d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
 {
-    interface IPreTimeStepSubscriber
+    public interface IPreTimeStepSubscriber
     {
         void PreTimeStepUpdate();
     }

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs
@@ -1,7 +1,13 @@
 ﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
 {
+    /// <summary>
+    /// A subscriber that is notified when a new time step starts
+    /// </summary>
     public interface IPreTimeStepSubscriber
     {
+        /// <summary>
+        /// The function the time manager calls when a new time step starts
+        /// </summary>
         void PreTimeStepUpdate();
     }
 }

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs
@@ -1,0 +1,7 @@
+﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
+{
+    interface IPreTimeStepSubscriber
+    {
+        void PreTimeStepUpdate();
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/IPreTimeStepSubscriber.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 174c86826717d6544b75a99a4a3897a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs
@@ -1,5 +1,8 @@
 ﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
 {
+    /// <summary>
+    /// A subscriber that is notified when a time step ends and a new one starts
+    /// </summary>
     public interface ITimeStepSubscriber : IPostTimeStepSubscriber, IPreTimeStepSubscriber
     {
     }

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
 {
-    interface ITimeStepSubscriber : IPostTimeStepSubscriber, IPreTimeStepSubscriber
+    public interface ITimeStepSubscriber : IPostTimeStepSubscriber, IPreTimeStepSubscriber
     {
     }
 }

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs
@@ -1,0 +1,6 @@
+﻿namespace SwordAndBored.Strategy.TimeSystem.Subscribers
+{
+    interface ITimeStepSubscriber : IPostTimeStepSubscriber, IPreTimeStepSubscriber
+    {
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/Subscribers/ITimeStepSubscriber.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83b4c0d35af8fee4fb609151e4ed9391
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8beb33515d928754eaeb731d8fc2c52f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
@@ -6,6 +6,8 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
     public abstract class AbstractTimeManager : MonoBehaviour, ITimeManager
     {
+        public ulong TimeStep { get; protected set; }
+
         protected abstract IList<IPreTimeStepSubscriber> PreTimeStepSubscribers { get; set; }
         protected abstract IList<IPostTimeStepSubscriber> PostTimeStepSubscribers { get; set; }
 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
@@ -6,17 +6,17 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
     public abstract class AbstractTimeManager : MonoBehaviour, ITimeManager
     {
-        protected readonly IList<IPreTimeStepSubscriber> preTimeStepSubscribers = new List<IPreTimeStepSubscriber>();
-        protected readonly IList<IPostTimeStepSubscriber> postTimeStepSubscribers = new List<IPostTimeStepSubscriber>();
+        protected abstract IList<IPreTimeStepSubscriber> PreTimeStepSubscribers { get; set; }
+        protected abstract IList<IPostTimeStepSubscriber> PostTimeStepSubscribers { get; set; }
 
         public virtual void AdvanceTimeStep()
         {
-            foreach (IPostTimeStepSubscriber postTimeStepSubscriber in postTimeStepSubscribers)
+            foreach (IPostTimeStepSubscriber postTimeStepSubscriber in PostTimeStepSubscribers)
             {
                 postTimeStepSubscriber.PostTimeStepUpdate();
             }
 
-            foreach (IPreTimeStepSubscriber preTimeStepSubscriber in preTimeStepSubscribers)
+            foreach (IPreTimeStepSubscriber preTimeStepSubscriber in PreTimeStepSubscribers)
             {
                 preTimeStepSubscriber.PreTimeStepUpdate();
             }
@@ -34,12 +34,12 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
             return success && Unsubscribe(subscriber as IPostTimeStepSubscriber);
         }
 
-        public void Subscribe(IPreTimeStepSubscriber subscriber) => preTimeStepSubscribers.Add(subscriber);
+        public void Subscribe(IPreTimeStepSubscriber subscriber) => PreTimeStepSubscribers.Add(subscriber);
 
-        public bool Unsubscribe(IPreTimeStepSubscriber subscriber) => preTimeStepSubscribers.Remove(subscriber);
+        public bool Unsubscribe(IPreTimeStepSubscriber subscriber) => PreTimeStepSubscribers.Remove(subscriber);
 
-        public void Subscribe(IPostTimeStepSubscriber subscriber) => postTimeStepSubscribers.Add(subscriber);
+        public void Subscribe(IPostTimeStepSubscriber subscriber) => PostTimeStepSubscribers.Add(subscriber);
 
-        public bool Unsubscribe(IPostTimeStepSubscriber subscriber) => postTimeStepSubscribers.Remove(subscriber);
+        public bool Unsubscribe(IPostTimeStepSubscriber subscriber) => PostTimeStepSubscribers.Remove(subscriber);
     }
 }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
@@ -1,9 +1,10 @@
 ﻿using SwordAndBored.Strategy.TimeSystem.Subscribers;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
-    abstract class AbstractTimeManager : ITimeManager
+    public abstract class AbstractTimeManager : MonoBehaviour, ITimeManager
     {
         protected readonly IList<IPreTimeStepSubscriber> preTimeStepSubscribers = new List<IPreTimeStepSubscriber>();
         protected readonly IList<IPostTimeStepSubscriber> postTimeStepSubscribers = new List<IPostTimeStepSubscriber>();

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
@@ -1,0 +1,44 @@
+﻿using SwordAndBored.Strategy.TimeSystem.Subscribers;
+using System.Collections.Generic;
+
+namespace SwordAndBored.Strategy.TimeSystem.TimeManager
+{
+    abstract class AbstractTimeManager : ITimeManager
+    {
+        protected readonly IList<IPreTimeStepSubscriber> preTimeStepSubscribers = new List<IPreTimeStepSubscriber>();
+        protected readonly IList<IPostTimeStepSubscriber> postTimeStepSubscribers = new List<IPostTimeStepSubscriber>();
+
+        public virtual void AdvanceTimeStep()
+        {
+            foreach (IPostTimeStepSubscriber postTimeStepSubscriber in postTimeStepSubscribers)
+            {
+                postTimeStepSubscriber.PostTimeStepUpdate();
+            }
+
+            foreach (IPreTimeStepSubscriber preTimeStepSubscriber in preTimeStepSubscribers)
+            {
+                preTimeStepSubscriber.PreTimeStepUpdate();
+            }
+        }
+
+        public void Subscribe(ITimeStepSubscriber subscriber)
+        {
+            Subscribe(subscriber as IPreTimeStepSubscriber);
+            Subscribe(subscriber as IPostTimeStepSubscriber);
+        }
+
+        public bool Unsubscribe(ITimeStepSubscriber subscriber)
+        {
+            bool success = Unsubscribe(subscriber as IPreTimeStepSubscriber);
+            return success && Unsubscribe(subscriber as IPostTimeStepSubscriber);
+        }
+
+        public void Subscribe(IPreTimeStepSubscriber subscriber) => preTimeStepSubscribers.Add(subscriber);
+
+        public bool Unsubscribe(IPreTimeStepSubscriber subscriber) => preTimeStepSubscribers.Remove(subscriber);
+
+        public void Subscribe(IPostTimeStepSubscriber subscriber) => postTimeStepSubscribers.Add(subscriber);
+
+        public bool Unsubscribe(IPostTimeStepSubscriber subscriber) => postTimeStepSubscribers.Remove(subscriber);
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2decbad3a78b934da4069bdf6773507
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
@@ -3,7 +3,7 @@ using SwordAndBored.Strategy.TimeSystem.Subscribers;
 
 namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
-    interface ITimeManager : IObserver<ITimeStepSubscriber>, IObserver<IPreTimeStepSubscriber>, IObserver<IPostTimeStepSubscriber>
+    public interface ITimeManager : IObserver<ITimeStepSubscriber>, IObserver<IPreTimeStepSubscriber>, IObserver<IPostTimeStepSubscriber>
     {
         void AdvanceTimeStep();
     }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
@@ -3,8 +3,14 @@ using SwordAndBored.Strategy.TimeSystem.Subscribers;
 
 namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
+    /// <summary>
+    /// An observer that notifies subscribers when a time step ends and a new time step starts
+    /// </summary>
     public interface ITimeManager : IObserver<ITimeStepSubscriber>, IObserver<IPreTimeStepSubscriber>, IObserver<IPostTimeStepSubscriber>
     {
+        /// <summary>
+        /// End the current time step and go to the next one
+        /// </summary>
         void AdvanceTimeStep();
     }
 }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
@@ -9,6 +9,11 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
     public interface ITimeManager : IObserver<ITimeStepSubscriber>, IObserver<IPreTimeStepSubscriber>, IObserver<IPostTimeStepSubscriber>
     {
         /// <summary>
+        /// The current time step
+        /// </summary>
+        ulong TimeStep { get; }
+
+        /// <summary>
         /// End the current time step and go to the next one
         /// </summary>
         void AdvanceTimeStep();

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
@@ -1,0 +1,10 @@
+﻿using SwordAndBored.Utilities;
+using SwordAndBored.Strategy.TimeSystem.Subscribers;
+
+namespace SwordAndBored.Strategy.TimeSystem.TimeManager
+{
+    interface ITimeManager : IObserver<ITimeStepSubscriber>, IObserver<IPreTimeStepSubscriber>, IObserver<IPostTimeStepSubscriber>
+    {
+        void AdvanceTimeStep();
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2304256b78ae2d4f8af4e2d7ecfa7cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
@@ -1,0 +1,36 @@
+﻿using SwordAndBored.Strategy.TimeSystem.Subscribers;
+using UnityEngine;
+using UnityEngine.UI;
+using SwordAndBored.Utilities.Debug;
+
+namespace SwordAndBored.Strategy.TimeSystem.TimeManager
+{
+    public class TimeDisplayController : MonoBehaviour, IPreTimeStepSubscriber
+    {
+        public TimeTrackingTimeManager timeManager;
+
+        private Text text;
+
+        void Start()
+        {
+            text = GetComponent<Text>();
+            AssertHelper.IsSetInEditor(timeManager, this);
+            timeManager.Subscribe(this);
+            text.text = string.Format("Turn: {0}", timeManager.TimeStep);            
+        }
+
+        public void PreTimeStepUpdate()
+        {
+            text.text = string.Format("Turn: {0}", timeManager.TimeStep);
+        }
+
+        public void OnDestroy()
+        {
+            if (timeManager)
+            {
+                timeManager.Unsubscribe(this);
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
@@ -7,7 +7,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
     public class TimeDisplayController : MonoBehaviour, IPreTimeStepSubscriber
     {
-        public TimeTrackingTimeManager timeManager;
+        public ITimeManager timeManager;
 
         private Text text;
 
@@ -27,7 +27,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 
         public void OnDestroy()
         {
-            if (timeManager)
+            if (!(timeManager is null))
             {
                 timeManager.Unsubscribe(this);
             }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
@@ -11,18 +11,19 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 
         private Text text;
 
-        void Start()
+        void Awake()
         {
             text = GetComponent<Text>();
             AssertHelper.IsSetInEditor(timeManager, this);
-            timeManager.Subscribe(this);
-            text.text = string.Format("Turn: {0}", timeManager.TimeStep);            
+            AssertHelper.IsSetInEditor(text, this);
+               
         }
 
-        public void PreTimeStepUpdate()
+        void Start()
         {
-            text.text = string.Format("Turn: {0}", timeManager.TimeStep);
-        }
+            timeManager.Subscribe(this);
+            PreTimeStepUpdate();
+        }        
 
         public void OnDestroy()
         {
@@ -30,6 +31,11 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
             {
                 timeManager.Unsubscribe(this);
             }
+        }
+
+        public void PreTimeStepUpdate()
+        {
+            text.text = string.Format("Turn: {0}", timeManager.TimeStep);
         }
     }
 }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs
@@ -16,7 +16,6 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
             text = GetComponent<Text>();
             AssertHelper.IsSetInEditor(timeManager, this);
             AssertHelper.IsSetInEditor(text, this);
-               
         }
 
         void Start()

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeDisplayController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 062b18826d8b41e43b3bcadb20b6a0eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs
@@ -5,7 +5,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
     public class TimeManagerKeyboardController : MonoBehaviour
     {
-        public TimeTrackingTimeManager timeManager;
+        public ITimeManager timeManager;
         public KeyCode nextTurnKey = KeyCode.Return;
 
 #if DEBUG

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs
@@ -9,14 +9,12 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
         public KeyCode nextTurnKey = KeyCode.Return;
 
 #if DEBUG
-        void Start()
+        void Awake()
         {
             AssertHelper.IsSetInEditor(timeManager, this);
         }
 #endif
 
-
-        // Update is called once per frame
         void Update()
         {
             if (Input.GetKeyDown(nextTurnKey))

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs
@@ -1,0 +1,28 @@
+﻿using UnityEngine;
+using SwordAndBored.Utilities.Debug;
+
+namespace SwordAndBored.Strategy.TimeSystem.TimeManager
+{
+    public class TimeManagerKeyboardController : MonoBehaviour
+    {
+        public TimeTrackingTimeManager timeManager;
+        public KeyCode nextTurnKey = KeyCode.Return;
+
+#if DEBUG
+        void Start()
+        {
+            AssertHelper.IsSetInEditor(timeManager, this);
+        }
+#endif
+
+
+        // Update is called once per frame
+        void Update()
+        {
+            if (Input.GetKeyDown(nextTurnKey))
+            {
+                timeManager.AdvanceTimeStep();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeManagerKeyboardController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7750ba802c98e64429dd3c5d6459d204
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
@@ -11,7 +11,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 
         public int startingTimeStep = 0;
 
-        public void Awake()
+        public TimeTrackingTimeManager()
         {
             TimeStep = startingTimeStep;
             PreTimeStepSubscribers = new List<IPreTimeStepSubscriber>();

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
@@ -1,21 +1,33 @@
 ﻿using SwordAndBored.Strategy.TimeSystem.Subscribers;
+using System.Collections.Generic;
 
 namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
-    class TimeTrackingTimeManager : AbstractTimeManager
+    public class TimeTrackingTimeManager : AbstractTimeManager
     {
-        public int TimeStep { get; protected set; } = 0;
+        public int TimeStep { get; protected set; }
+        protected override IList<IPreTimeStepSubscriber> PreTimeStepSubscribers { get; set; }
+        protected override IList<IPostTimeStepSubscriber> PostTimeStepSubscribers { get; set; }
+
+        public int startingTimeStep = 0;
+
+        public void Awake()
+        {
+            TimeStep = startingTimeStep;
+            PreTimeStepSubscribers = new List<IPreTimeStepSubscriber>();
+            PostTimeStepSubscribers = new List<IPostTimeStepSubscriber>();
+        }
 
         public override void AdvanceTimeStep()
         {
-            foreach (IPostTimeStepSubscriber postTimeStepSubscriber in postTimeStepSubscribers)
+            foreach (IPostTimeStepSubscriber postTimeStepSubscriber in PostTimeStepSubscribers)
             {
                 postTimeStepSubscriber.PostTimeStepUpdate();
             }
 
             TimeStep++;
 
-            foreach (IPreTimeStepSubscriber preTimeStepSubscriber in preTimeStepSubscribers)
+            foreach (IPreTimeStepSubscriber preTimeStepSubscriber in PreTimeStepSubscribers)
             {
                 preTimeStepSubscriber.PreTimeStepUpdate();
             }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
@@ -1,0 +1,24 @@
+﻿using SwordAndBored.Strategy.TimeSystem.Subscribers;
+
+namespace SwordAndBored.Strategy.TimeSystem.TimeManager
+{
+    class TimeTrackingTimeManager : AbstractTimeManager
+    {
+        public int TimeStep { get; protected set; } = 0;
+
+        public override void AdvanceTimeStep()
+        {
+            foreach (IPostTimeStepSubscriber postTimeStepSubscriber in postTimeStepSubscribers)
+            {
+                postTimeStepSubscriber.PostTimeStepUpdate();
+            }
+
+            TimeStep++;
+
+            foreach (IPreTimeStepSubscriber preTimeStepSubscriber in preTimeStepSubscribers)
+            {
+                preTimeStepSubscriber.PreTimeStepUpdate();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
@@ -5,11 +5,10 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
     public class TimeTrackingTimeManager : AbstractTimeManager
     {
-        public int TimeStep { get; protected set; }
         protected override IList<IPreTimeStepSubscriber> PreTimeStepSubscribers { get; set; }
         protected override IList<IPostTimeStepSubscriber> PostTimeStepSubscribers { get; set; }
 
-        public int startingTimeStep = 0;
+        public ulong startingTimeStep = 0;
 
         public TimeTrackingTimeManager()
         {

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs.meta
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5411f1825cf34c041a1dd04719537b27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/IObserver.cs
+++ b/Assets/Scripts/Utilities/IObserver.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwordAndBored.Utilities
 {
-    interface IObserver<T>
+    public interface IObserver<T>
     {
         /// <summary>
         /// Adds the subscriber to the observer's list of objects to be notified
@@ -16,7 +16,7 @@
         bool Unsubscribe(T subscriber);
     }
 
-    interface IObserver
+    public interface IObserver
     {
         /// <summary>
         /// Adds the subscriber to the observer's list of objects to be notified

--- a/Assets/Scripts/Utilities/IObserver.cs
+++ b/Assets/Scripts/Utilities/IObserver.cs
@@ -1,0 +1,34 @@
+﻿namespace SwordAndBored.Utilities
+{
+    interface IObserver<T>
+    {
+        /// <summary>
+        /// Adds the subscriber to the observer's list of objects to be notified
+        /// </summary>
+        /// <param name="subscriber">The object that is subscribing to the observer</param>
+        void Subscribe(T subscriber);
+
+        /// <summary>
+        /// Attempts to remove the subscriber from the list of subscribed objects
+        /// </summary>
+        /// <param name="subscriber">The object to remove</param>
+        /// <returns>Whether the object was successfully removed</returns>
+        bool Unsubscribe(T subscriber);
+    }
+
+    interface IObserver
+    {
+        /// <summary>
+        /// Adds the subscriber to the observer's list of objects to be notified
+        /// </summary>
+        /// <param name="subscriber">The object that is subscribing to the observer</param>
+        void Subscribe(object subscriber);
+
+        /// <summary>
+        /// Attempts to remove the subscriber from the list of subscribed objects
+        /// </summary>
+        /// <param name="subscriber">The object to remove</param>
+        /// <returns>Whether the object was successfully removed</returns>
+        bool Unsubscribe(object subscriber);
+    }
+}

--- a/Assets/Scripts/Utilities/IObserver.cs.meta
+++ b/Assets/Scripts/Utilities/IObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06b97707c3a353a4aa472f6ef3c8ddce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #108 

Changes proposed in this pull request:
- Creates an observer/subscriber pattern time system that allows objects to subscribe to the time system and get a "notification" when the turn changes
- A prefab that can be added to the strategy map that shows the current turn and provides two ways to increment the turn to the player, an end turn button, as well as the enter button
- The observer has two ways that it can notify a turn has passed, a post turn notification and a pre turn notification. It notifies in the following way: `End Turn Signaled -> Post Turn Notification -> Turn number increased -> Pre Turn Notification`. The idea being that the "turn" is when the player has control and when they press the end button the game gets a chance to do something before the turn ends, and the game gets a chance to do something before the player does on a turn

