### PR TITLE
192 movement bug

### DIFF
--- a/Assets/Scripts/Strategy/EnemyManagement/Spawning/DemoSpawner.cs
+++ b/Assets/Scripts/Strategy/EnemyManagement/Spawning/DemoSpawner.cs
@@ -43,5 +43,5 @@ namespace SwordAndBored.Strategy.EnemyManagement.Spawning
             enemy.StartLocation = location;
             turnManager.Subscribe(enemy);
         }
-}
+    }
 }

--- a/Assets/Scripts/Strategy/Movement/CreatureMovementController.cs
+++ b/Assets/Scripts/Strategy/Movement/CreatureMovementController.cs
@@ -59,7 +59,8 @@ namespace SwordAndBored.Strategy.Movement
             AssertHelper.Assert(StartLocation != null, "No start location given", this);
             AssertHelper.Assert(!StartLocation.HasComponent<CreatureComponent>(), 
                 "Tried to place creature on creature at " + StartLocation.Position, this);
-            UpdateLocation(StartLocation);
+            bool success = UpdateLocation(StartLocation);
+            AssertHelper.Assert(success, "Failed to set start location", this);
             targetPosition = null;
             height = transform.position.y;
             distanceCanTravel = ResetMovement();

--- a/Assets/Scripts/Strategy/Movement/EnemyMovementController.cs
+++ b/Assets/Scripts/Strategy/Movement/EnemyMovementController.cs
@@ -49,13 +49,17 @@ namespace SwordAndBored.Strategy.Movement
 
         private void DeterminePath()
         {
+            path.Clear();
+            AssertHelper.Assert(Location != null, "Location was null!", this);
             IHexGridCell gridCell = Location;
             for (int i = 0; i < averageMovement; i++)
             {
+                IHexGridCell tempGridCell;
                 do
                 {
-                    gridCell = Odds.SelectAtRandom(gridCell.Neighbors);
-                } while (gridCell is null);
+                    tempGridCell = Odds.SelectAtRandom(gridCell.Neighbors);
+                } while (tempGridCell is null);
+                gridCell = tempGridCell;
                 path.Enqueue(gridCell);
             }
         }

--- a/Assets/Scripts/Strategy/Squads/SquadController.cs
+++ b/Assets/Scripts/Strategy/Squads/SquadController.cs
@@ -7,9 +7,22 @@ namespace SwordAndBored.Strategy.Squads
 {
     public class SquadController : GenericSquadController
     {
+        private bool wipePath;
+
+        public override void PreTimeStepUpdate()
+        {
+            base.PreTimeStepUpdate();
+            wipePath = true;
+        }
+
         public override void GoTo(IHexGridCell location)
         {
             //Make A* call here
+            if (wipePath)
+            {
+                path.Clear();
+                wipePath = false;
+            }
             path.Enqueue(location);
             TraversePath();
         }

--- a/Assets/Scripts/Strategy/Squads/SquadManager.cs
+++ b/Assets/Scripts/Strategy/Squads/SquadManager.cs
@@ -74,6 +74,7 @@ namespace SwordAndBored.Strategy.Squads
 
         public void OnTileSelect(IHexGridCell selectedTile)
         {
+            if (turnManager.IsTimeStepAdvancing) return;
             SquadController squad = GetSquadOnTile(selectedTile);
             if (squad)
             {

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
@@ -6,9 +6,11 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
     public abstract class AbstractTimeManager : MonoBehaviour, ITimeManager
     {
+        [SerializeField] private bool isTimeStepAdvancing;
+
         public ulong TimeStep { get; protected set; }
 
-        public bool IsTimeStepAdvancing { get; protected set; }
+        public bool IsTimeStepAdvancing { get => isTimeStepAdvancing; protected set => isTimeStepAdvancing = value; }
 
         protected abstract IList<IPreTimeStepSubscriber> PreTimeStepSubscribers { get; set; }
         protected abstract IList<IPostTimeStepSubscriber> PostTimeStepSubscribers { get; set; }

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/AbstractTimeManager.cs
@@ -8,6 +8,8 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
     {
         public ulong TimeStep { get; protected set; }
 
+        public bool IsTimeStepAdvancing { get; protected set; }
+
         protected abstract IList<IPreTimeStepSubscriber> PreTimeStepSubscribers { get; set; }
         protected abstract IList<IPostTimeStepSubscriber> PostTimeStepSubscribers { get; set; }
 

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/ITimeManager.cs
@@ -14,6 +14,11 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
         ulong TimeStep { get; }
 
         /// <summary>
+        /// Returns true if AdvanceTimeStep is currently running
+        /// </summary>
+        bool IsTimeStepAdvancing { get; }
+
+        /// <summary>
         /// End the current time step and go to the next one
         /// </summary>
         void AdvanceTimeStep();

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
@@ -19,6 +19,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
             TimeStep = (SceneSharing.useStoredTimeStep) ? SceneSharing.timeStep : startingTimeStep;
             PreTimeStepSubscribers = new List<IPreTimeStepSubscriber>();
             PostTimeStepSubscribers = new List<IPostTimeStepSubscriber>();
+            IsTimeStepAdvancing = false;
         }
 
         public override void AdvanceTimeStep()
@@ -45,6 +46,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
             }
             try
             {
+                IsTimeStepAdvancing = true;
                 List<Task> tasks = new List<Task>();
                 foreach (IPostTimeStepSubscriber postTimeStepSubscriber in PostTimeStepSubscribers)
                 {
@@ -60,6 +62,7 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
                     tasks.Add(Task.Run(preTimeStepSubscriber.PreTimeStepUpdate));
                 }
                 Task.WaitAll(tasks.ToArray());
+                IsTimeStepAdvancing = false;
             }
             finally
             {

--- a/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
+++ b/Assets/Scripts/Strategy/TimeSystem/TimeManager/TimeTrackingTimeManager.cs
@@ -1,8 +1,10 @@
 ﻿using SwordAndBored.Strategy.TimeSystem.Subscribers;
 using SwordAndBored.Strategy.Transitions;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace SwordAndBored.Strategy.TimeSystem.TimeManager
 {
@@ -62,10 +64,24 @@ namespace SwordAndBored.Strategy.TimeSystem.TimeManager
                     tasks.Add(Task.Run(preTimeStepSubscriber.PreTimeStepUpdate));
                 }
                 Task.WaitAll(tasks.ToArray());
-                IsTimeStepAdvancing = false;
+            }
+            catch (AggregateException exceptions)
+            {
+                Debug.LogWarning("Exception(s) detected during advancing of time step");
+                exceptions.Handle((x) => 
+                {
+                    Debug.LogException(x);
+                    return true;
+                }) ;
+                Debug.Log("End of advancing of time step exceptions");
+            }
+            catch (Exception exception)
+            {
+                Debug.LogException(exception);
             }
             finally
             {
+                IsTimeStepAdvancing = false;
                 Monitor.Exit(timeStepLock);
             }
         }


### PR DESCRIPTION
Fixes #192 

Changes proposed in this pull request:
- Fixes squad movement to clear previously queued path if path is changed on next turn
- Add error logging in time manager to print previously suppressed errors
- Fix enemy movement bug that was being suppressed by time system

